### PR TITLE
Fixes #34 logged on Knox-mpu

### DIFF
--- a/lib/multipartupload.js
+++ b/lib/multipartupload.js
@@ -111,6 +111,14 @@ util.inherits(MultiPartUpload, EventEmitter);
  */
 MultiPartUpload.prototype._initiate = function(callback) {
 
+    if( this.objectName && this.objectName.indexOf(' ') != -1 ){
+        /*Replace the spaces in the name with URL encode.
+        If the spaces are retained, "path" in the HTTP request will be deemed invalid.
+        Not using native JS API for url encode, because the name might have a forward slash,
+        that needs to be retained.*/
+        this.objectName = this.objectName.replace(/ /g, '%20');
+    }
+
     // Send the initiate request
     var req = this.client.request('POST', this.objectName + '?uploads', this.headers),
         mpu = this;


### PR DESCRIPTION
The "path" in a HTTP request uses space as a delimiter. If a file name contains a space, the HTTP request will be,
    GET /New Text Document.txt HTTP/1.1
This will result in AWS returning an "Unsupported HTTP version" error, because HTTP does not understand the extra "Text Document.txt" in the HTTP request.
The fix is to replace the spaces in the "path" with the url encoded string "%20". The new request will now be,
    GET /New%20Text%20Document.txt HTTP/1.1
Note: We cannot use the native JS encodeURI(). This is because the file name can have a '/' to indicate the folder structure of your S3 bucket.
For Ex. If you are uploading a picture, to a folder called "pictures" in your S3 bucket, you will have to specify the file name as "/pictures/New Pic.jpg".
The encoded version of this will be "%2Fpictures%2FNew%20Pic.jpg".
If you take a look at "Client.prototype.request" in client.js in the Knox library, you will see that if a file name does not start with a '/', Knox adds one.
This will result in a file named "%2Fpictures%2FNew%20Pic.jpg" being uploaded to the root directory of your S3 bucket.
